### PR TITLE
Patch/elastic log4j

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -25,7 +25,7 @@ dependencies:
     condition: airflow.enabled
     repository: "https://airflow-helm.github.io/charts"
   - name: elasticsearch
-    version: "7.12.0"
+    version: "7.16"
     repository: "https://helm.elastic.co"
     condition: elasticsearch.enabled
   - name: redis

--- a/values.yaml
+++ b/values.yaml
@@ -208,6 +208,8 @@ elasticsearch:
         secretKeyRef:
           name: search-elastic-secret
           key: username
+    - name: LOG4J_FORMAT_MSG_NO_LOOKUPS
+      value: "true"
 
 nboost:
   enabled: false

--- a/values.yaml
+++ b/values.yaml
@@ -194,7 +194,9 @@ elasticsearch:
   enabled: true
   imageTag: "7.12.0"
   replicas: 1
-
+  # default, maybe we ought to increase this as size increases
+  # esJavaOpts: "-Xmx1g -Xms1g"
+  esJavaOpts: "-Xmx1g -Xms1g -Dlog4j2.disable.jmx=true -Dlog4j2.formatMsgNoLookups=true"
   extraEnvs:
     - name: ELASTIC_PASSWORD
       valueFrom:

--- a/values.yaml
+++ b/values.yaml
@@ -192,7 +192,7 @@ config:
 
 elasticsearch:
   enabled: true
-  imageTag: "7.12.0"
+  imageTag: "7.16.1"
   replicas: 1
   # default, maybe we ought to increase this as size increases
   # esJavaOpts: "-Xmx1g -Xms1g"


### PR DESCRIPTION
- It seems like Elastic is using log4j v 2.11.1 (https://search.maven.org/artifact/org.elasticsearch/elasticsearch/7.12.0/jar) 
- I think following to what people are recommending in several blogs having the flags and the env var should be sufficient 
- This hopefully would add an extra layer to Elastic's dev comments towards the issue (https://discuss.elastic.co/t/apache-log4j2-remote-code-execution-rce-vulnerability-cve-2021-44228-esa-2021-31/291476) 