### PR TITLE
few edits here and there

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.1.24
+version: 4.0.0
 
 appVersion: "2.10.2"
 

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 3.1.24
 
-appVersion: "2.9.8"
+appVersion: "2.10.2"
 
 dependencies:
   - name: airflow

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.0.24
+version: 3.1.24
 
 appVersion: "2.9.8"
 
@@ -39,4 +39,8 @@ dependencies:
   - name: redis-insight
     version: "0.1.0"
     condition: redis-insight.enabled
+    repository: "@helx-charts"
+  - name: ui
+    condition: ui.enabled
+    version: "^1.0.0"
     repository: "@helx-charts"

--- a/templates/api-deployment.yaml
+++ b/templates/api-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: {{ .Values.api.appName}}
 spec:
-  replicas: 1
+  replicas: {{ .Values.api.replicas }}
   selector:
     matchLabels:
       app: {{ .Values.api.appName}}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -2,18 +2,15 @@
 {{- if .Values.ingress.enabled -}}
 {{- $ingressPaths := .Values.ingress.paths }}
 {{- $ingressRewritePaths := .Values.ingress.rewrite_paths }}
+{{- $releaseName := .Release.Name }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "search.fullname" . }}
   labels:
-    {{- include "search.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
+    {{- include "search.labels" . | nindent 4 }}  
   annotations:
-    nginx.ingress.kubernetes.io/enable-cors: "true"
-    nginx.ingress.kubernetes.io/cors-allow-origin: "*"
-    nginx.ingress.kubernetes.io/cors-allow-methods: "POST, OPTIONS"
-    nginx.ingress.kubernetes.io/cors-allow-headers: "Content-Type"
+  {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
@@ -38,7 +35,7 @@ spec:
           backend:
             service:
               {{- if .prepend }}
-              name: {{ include "search.fullname" $ -}}-{{- .name }}
+              name: {{ $releaseName -}}-{{- .name }}
               {{- else }}
               name: {{ .name }}
               {{- end }}
@@ -53,14 +50,10 @@ kind: Ingress
 metadata:
   name: {{ include "search.fullname" . }}-rewrite
   labels:
-    {{- include "search.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
-  annotations:
-    nginx.ingress.kubernetes.io/enable-cors: "true"
-    nginx.ingress.kubernetes.io/cors-allow-origin: "*"
-    nginx.ingress.kubernetes.io/cors-allow-methods: "POST, OPTIONS"
-    nginx.ingress.kubernetes.io/cors-allow-headers: "Content-Type"
+    {{- include "search.labels" . | nindent 4 }}  
+  annotations:    
     nginx.ingress.kubernetes.io/rewrite-target: /$2
+  {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
@@ -85,7 +78,7 @@ spec:
           backend:
             service:
               {{- if .prepend }}
-              name: {{ include "search.fullname" $ -}}-{{- .name }}
+              name: {{ $releaseName }}-{{- .name }}
               {{- else }}
               name: {{ .name }}
               {{- end }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -8,6 +8,7 @@
    {{ $secretName := printf "%s-htpasswd" .Release.Name}}
    {{ $_ := set .Values.ingress.annotations "nginx.ingress.kubernetes.io/auth-secret" $secretName}}
 {{ end }}
+{{- $pathType := .Values.ingress.pathType }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -19,6 +20,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{ if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className | quote }}
+  {{ end }}
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}
@@ -36,7 +40,7 @@ spec:
       paths:
         {{- range $ingressPaths }}
         - path: {{ .path }}
-          pathType: Prefix
+          pathType: {{ $pathType }}
           backend:
             service:
               {{- if .prepend }}
@@ -62,6 +66,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{ if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className | quote }}
+  {{ end }}
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}
@@ -79,7 +86,7 @@ spec:
       paths:
         {{- range $ingressRewritePaths }}
         - path: {{ .path }}
-          pathType: Prefix
+          pathType: {{ $pathType }}
           backend:
             service:
               {{- if .prepend }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -3,6 +3,11 @@
 {{- $ingressPaths := .Values.ingress.paths }}
 {{- $ingressRewritePaths := .Values.ingress.rewrite_paths }}
 {{- $releaseName := .Release.Name }}
+{{ if .Values.ingress.basicAuth.enabled }}
+   {{ $_ := set .Values.ingress.annotations "nginx.ingress.kubernetes.io/auth-type" "basic" }}
+   {{ $secretName := printf "%s-htpasswd" .Release.Name}}
+   {{ $_ := set .Values.ingress.annotations "nginx.ingress.kubernetes.io/auth-secret" $secretName}}
+{{ end }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/templates/secrets.yaml
+++ b/templates/secrets.yaml
@@ -37,3 +37,12 @@ data:
   {{ else }}
   fernet-key: {{ index (lookup "v1" "Secret" .Release.Namespace ( .Values.airflow.airflow.configSecretsName )).data "fernet-key" }}
   {{ end }}
+---
+{{ if .Values.ingress.basicAuth.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-htpasswd
+data:
+  auth: {{ htpasswd .Values.ingress.basicAuth.username .Values.ingress.basicAuth.password | b64enc | quote }}
+{{ end }}

--- a/values.yaml
+++ b/values.yaml
@@ -204,7 +204,7 @@ api:
   replicas: 4
   image:
     repository: containers.renci.org/helxplatform/dug
-    tag: "latest"
+    tag: ""
     pullPolicy: Always
   appName: webserver
   debug: false

--- a/values.yaml
+++ b/values.yaml
@@ -429,7 +429,7 @@ redis-insight:
 ui:
   enabled: False
   config:
-    brand_name: heal
+    brand_name: ""
     search:
       enabled: "true"
       ## Escaped search endpoint address eg: https:\/\/example.com\/search-api

--- a/values.yaml
+++ b/values.yaml
@@ -203,14 +203,14 @@ airflow:
 api:
   replicas: 4
   image:
-    repository: helxplatform/dug
-    tag: ""
+    repository: containers.renci.org/helxplatform/dug
+    tag: "latest"
     pullPolicy: Always
   appName: webserver
   debug: false
   deployment:
     apiPort: 5551
-    apiWorkers: 4
+    apiWorkers: 8
     apiTimeout: 10
     extraEnv: []
     logLevel: INFO
@@ -218,10 +218,10 @@ api:
     resources:
       limits:
         cpu: 2
-        memory: 2G
+        memory: 1G
       requests:
         cpu: 2
-        memory: 2G
+        memory: 1G
   service:
     name: search-api
     annotations: {}

--- a/values.yaml
+++ b/values.yaml
@@ -276,6 +276,10 @@ elasticsearch:
 
 ingress:
   enabled: false
+  basicAuth:
+    enabled: false
+    username: ""
+    password: ""
   annotations: 
     nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/cors-allow-origin: "*"

--- a/values.yaml
+++ b/values.yaml
@@ -261,22 +261,24 @@ elasticsearch:
       value: "true"
   imageTag: "7.16.3"
   maxUnavailable: 0
-  replicas: 1
+  replicas: 3
   resources:
     limits:
       cpu: 1
-      memory: 2G
+      memory: 4G
     requests:
       cpu: 1
-      memory: 2G
+      memory: 4G
   sysctlInitContainer:
     enabled: false
 fullnameOverride: ""
 ingress:
   enabled: false
-  annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
+  annotations: 
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+    nginx.ingress.kubernetes.io/cors-allow-origin: "*"
+    nginx.ingress.kubernetes.io/cors-allow-methods: "POST, OPTIONS"
+    nginx.ingress.kubernetes.io/cors-allow-headers: "Content-Type"
   hosts:
     - host: chart-example.local
   labels: {}
@@ -284,7 +286,7 @@ ingress:
     - path: "/"
       name: ui
       port: 80
-      prepend: false
+      prepend: true
     - path: "/airflow"
       name: web
       port: 8080
@@ -423,3 +425,23 @@ redis-insight:
   enabled: false
   # -- Url should be same as public ingress url
   rootUrl: ""
+
+ui:
+  enabled: False
+  config:
+    brand_name: heal
+    search:
+      enabled: "true"
+      ## Escaped search endpoint address eg: https:\/\/example.com\/search-api
+      url: ""
+    tranql_enabled: "true"
+    ## Escaped tranql endpoint address eg: https:\/\/example.com\/tranql
+    tranql_url: ""
+    workspaces:
+      # disable workspaces
+      enabled: "false"
+    hidden_result_tabs: "cdes"
+  image:
+    pullPolicy: Always
+    repository: containers.renci.org/helxplatform/helx-ui
+    tag: v5.0.0

--- a/values.yaml
+++ b/values.yaml
@@ -275,6 +275,8 @@ elasticsearch:
     enabled: false
 
 ingress:
+  pathType: Prefix
+  className: ""
   enabled: false
   basicAuth:
     enabled: false

--- a/values.yaml
+++ b/values.yaml
@@ -1,3 +1,5 @@
+fullnameOverride: ""
+nameOverride: ""
 airflow:
   enabled: true
   pgbouncer:
@@ -144,11 +146,9 @@ airflow:
     kubernetesPodTemplate:
       resources:
         limits:
-          ephemeral-storage: 4G
           cpu: 2
           memory: 16G
         requests:
-          ephemeral-storage: 4G
           cpu: 2
           memory: 16G
     usersUpdate: true
@@ -201,10 +201,11 @@ airflow:
   triggerer:
     enabled: false
 api:
+  replicas: 4
   image:
     repository: helxplatform/dug
     tag: ""
-    pullPolicy: IfNotPresent
+    pullPolicy: Always
   appName: webserver
   debug: false
   deployment:
@@ -229,10 +230,10 @@ api:
     type: ClusterIP
 config:
   annotation:
-    normalizer_url: http://nn-web-prod-node-normalization-web-service-root.translator.svc.cluster.local:8080/get_normalized_nodes?conflate=false&curie=
+    normalizer_url: https://nodenormalization-sri.renci.org/get_normalized_nodes?conflate=false&curie=
     annotator_url: https://api.monarchinitiative.org/api/nlp/annotate/entities?min_length=4&longest_only=false&include_abbreviation=false&include_acronym=false&include_numbers=false&content=
     synonymizer_url: https://onto.renci.org/synonyms/
-  input_sets: "bdc-dbGaP,topmed"
+  input_sets: "bdc:v2.0,topmed:v2.0"
   data_source: "stars"
   kgx_data_sets: "baseline-graph,cde-graph"
   node_to_queries_enabled: "false"
@@ -245,7 +246,8 @@ elasticsearch:
   # default, maybe we ought to increase this as size increases
   # esJavaOpts: "-Xmx1g -Xms1g"
   enabled: true
-  esJavaOpts: "-Xmx1g -Xms1g -Dlog4j2.disable.jmx=true -Dlog4j2.formatMsgNoLookups=true"
+  esJavaOpts: "-Xmx6g -Xms6g -Dlog4j2.disable.jmx=true -Dlog4j2.formatMsgNoLookups=true"
+  clusterHealthCheckParams: "wait_for_status=green&timeout=1s"
   extraEnvs:
     - name: ELASTIC_PASSWORD
       valueFrom:
@@ -265,13 +267,13 @@ elasticsearch:
   resources:
     limits:
       cpu: 1
-      memory: 4G
+      memory: 8G
     requests:
       cpu: 1
-      memory: 4G
+      memory: 8G
   sysctlInitContainer:
     enabled: false
-fullnameOverride: ""
+
 ingress:
   enabled: false
   annotations: 
@@ -304,9 +306,7 @@ ingress:
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
-nameOverride: ""
-nboost:
-  enabled: false
+
 persistence:
   storageClass: ""
   pvcSize: 32Gi
@@ -358,7 +358,7 @@ redis:
     autoscaling:
       enabled: true
       minReplicas: 1
-      maxReplicas: 2
+      maxReplicas: 1
       targetCPU: 100
     persistence:
       size: 24G


### PR DESCRIPTION
- Adds UI chart as a dependency
     This chart is disabled by default to still be compatibile with Helx chart
- Ingress service name resolution based on release name vs full name
- Elastic search pods increased number of replicas for throughput